### PR TITLE
Add React dashboard skeleton

### DIFF
--- a/crm-dashboard/package.json
+++ b/crm-dashboard/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "crm-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "axios": "^1.4.0",
+    "dayjs": "^1.11.5"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  }
+}

--- a/crm-dashboard/public/index.html
+++ b/crm-dashboard/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CRM Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/crm-dashboard/src/App.css
+++ b/crm-dashboard/src/App.css
@@ -1,0 +1,20 @@
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  margin: 0;
+  padding: 1rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+th, td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+}
+
+th {
+  background-color: #f2f2f2;
+}

--- a/crm-dashboard/src/App.jsx
+++ b/crm-dashboard/src/App.jsx
@@ -1,0 +1,18 @@
+import React, { useState } from 'react';
+import LoanRequestTable from './components/LoanRequestTable';
+import LoanRequestFilters from './components/LoanRequestFilters';
+import SummaryPanel from './components/SummaryPanel';
+import './App.css';
+
+export default function App() {
+  const [filters, setFilters] = useState({});
+
+  return (
+    <div className="App">
+      <h1>CRM Loan Requests</h1>
+      <LoanRequestFilters onChange={setFilters} />
+      <SummaryPanel filters={filters} />
+      <LoanRequestTable filters={filters} />
+    </div>
+  );
+}

--- a/crm-dashboard/src/components/LoanRequestFilters.jsx
+++ b/crm-dashboard/src/components/LoanRequestFilters.jsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+
+export default function LoanRequestFilters({ onChange }) {
+  const [local, setLocal] = useState({});
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    const next = { ...local, [name]: value };
+    setLocal(next);
+    onChange(next);
+  };
+
+  return (
+    <div>
+      <label>
+        From:
+        <input type="date" name="from" onChange={handleChange} />
+      </label>
+      <label>
+        To:
+        <input type="date" name="to" onChange={handleChange} />
+      </label>
+      <label>
+        Group:
+        <input type="text" name="group" onChange={handleChange} />
+      </label>
+      <label>
+        Status:
+        <select name="status" onChange={handleChange}>
+          <option value="">All</option>
+          <option value="pending">pending</option>
+          <option value="approved">approved</option>
+          <option value="rejected">rejected</option>
+          <option value="unclear">unclear</option>
+        </select>
+      </label>
+    </div>
+  );
+}

--- a/crm-dashboard/src/components/LoanRequestRow.jsx
+++ b/crm-dashboard/src/components/LoanRequestRow.jsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { updateLoanRequest } from '../services/api';
+
+export default function LoanRequestRow({ data }) {
+  const [request, setRequest] = useState(data);
+
+  const handleStatus = (e) => {
+    const status = e.target.value;
+    updateLoanRequest(request.id, { status }).then((res) => {
+      setRequest(res.data);
+    });
+  };
+
+  const handleAmount = () => {
+    const amount = prompt('Amount', request.amount_requested || '');
+    if (amount !== null) {
+      updateLoanRequest(request.id, { amount_requested: amount }).then((res) => {
+        setRequest(res.data);
+      });
+    }
+  };
+
+  return (
+    <tr>
+      <td>{new Date(request.timestamp_created).toLocaleDateString()}</td>
+      <td>{request.group_name}</td>
+      <td>{request.amount_requested || '—'}</td>
+      <td>
+        <select value={request.status} onChange={handleStatus}>
+          <option value="pending">pending</option>
+          <option value="approved">approved</option>
+          <option value="rejected">rejected</option>
+          <option value="unclear">unclear</option>
+        </select>
+      </td>
+      <td>{request.content}</td>
+      <td>
+        <button onClick={handleAmount}>Edit Amount</button>
+      </td>
+    </tr>
+  );
+}

--- a/crm-dashboard/src/components/LoanRequestTable.jsx
+++ b/crm-dashboard/src/components/LoanRequestTable.jsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+import { getLoanRequests } from '../services/api';
+import LoanRequestRow from './LoanRequestRow';
+
+export default function LoanRequestTable({ filters }) {
+  const [requests, setRequests] = useState([]);
+
+  useEffect(() => {
+    getLoanRequests(filters).then((res) => setRequests(res.data));
+  }, [filters]);
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Group</th>
+          <th>Amount</th>
+          <th>Status</th>
+          <th>Content</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {requests.map((r) => (
+          <LoanRequestRow key={r.id} data={r} />
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/crm-dashboard/src/components/SummaryPanel.jsx
+++ b/crm-dashboard/src/components/SummaryPanel.jsx
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from 'react';
+import { getLoanRequests } from '../services/api';
+
+export default function SummaryPanel({ filters }) {
+  const [summary, setSummary] = useState({ total: 0, amount: 0, approved: 0 });
+
+  useEffect(() => {
+    getLoanRequests(filters).then((res) => {
+      const data = res.data;
+      const total = data.length;
+      const amount = data.reduce((sum, r) => sum + (Number(r.amount_requested) || 0), 0);
+      const approved = data
+        .filter((r) => r.status === 'approved')
+        .reduce((sum, r) => sum + (Number(r.amount_requested) || 0), 0);
+      setSummary({ total, amount, approved });
+    });
+  }, [filters]);
+
+  return (
+    <div style={{ marginTop: '1rem' }}>
+      <strong>Total Requests:</strong> {summary.total}
+      {' | '}
+      <strong>Total Amount:</strong> {summary.amount}
+      {' | '}
+      <strong>Approved:</strong> {summary.approved}
+    </div>
+  );
+}

--- a/crm-dashboard/src/index.js
+++ b/crm-dashboard/src/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './App.css';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/crm-dashboard/src/services/api.js
+++ b/crm-dashboard/src/services/api.js
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+const API = axios.create({
+  baseURL: 'http://localhost:5000/api',
+});
+
+export const getLoanRequests = (filters = {}) =>
+  API.get('/loan_requests', { params: filters });
+
+export const updateLoanRequest = (id, data) =>
+  API.put(`/loan_requests/${id}`, data);


### PR DESCRIPTION
## Summary
- scaffold a simple React dashboard
- implement table, filters, row editing and summary panel
- include basic API helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850534c64748322bf046f46c5bd9cbb